### PR TITLE
syntax to use near '))' at line 1

### DIFF
--- a/webmain/model/viewModel.php
+++ b/webmain/model/viewModel.php
@@ -163,7 +163,7 @@ class viewClassModel extends Model
 				}
 			}
 			
-			if(!isempt($sw))$wehs[] = '('.$sw.')';
+			if(!isempt(trim($sw)))$wehs[] = '('.$sw.')';
 		}
 		
 		if($type==6)return $rows;//禁看类型字段 


### PR DESCRIPTION
[ERROR SQL]
SELECT count(1) FROM xinhu_whcsmk WHERE `id`='1'   and (( ))

[Reason]
mysqliError:You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '))' at line 1

[URL]
https://sj.test.cn/task.php?a=p&num=whcsmk0&mid=1&callback=opegs1632753308264_7242

 

[datetime]
2021-09-27 22:53:03

[Browser]
Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36 Edg/89.0.774.57